### PR TITLE
fix(utils): fix .toString() method in extended classes

### DIFF
--- a/src/utils/FinalDecorator.ts
+++ b/src/utils/FinalDecorator.ts
@@ -30,8 +30,8 @@ export function Final(...properties: string[]) {
         super(...props)
 
         properties.forEach(property => {
-          if (typeof this[property] === 'function') {
-            this[property].toString = function () {
+          if (typeof super[property] === 'function') {
+            super[property].toString = function () {
               return `function ${property}() { [ddoo internal code] }`
             }
           }


### PR DESCRIPTION
Fixed following issue: if we extend a class with a final decorator attached to some method, then override it and call .toString() somewhere, we can get the source code of the parent class method